### PR TITLE
Add pkg-config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,10 +11,14 @@ AM_CPPFLAGS = \
 	$(nfcDemoApp_FLAGS)
 
 configdir = ${sysconfdir}
+pkgconfiglibdir = $(libdir)/pkgconfig
 
 if PN7120
 config_DATA = conf/PN7120/libnfc-brcm.conf conf/PN7120/libnfc-nxp.conf
 endif
+
+pkgconfiglib_DATA = \
+	libnfc-nci.pc
 
 LIBNFC_NCI_INCLUDE := \
 	src/libnfc-nci/include \

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ AC_CHECK_FUNCS([select])
 AC_CHECK_FUNCS([dlopen])
 
 AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([libnfc-nci.pc])
 
 AC_ARG_ENABLE([pn7120],
 [  --enable-pn7120    set chip version to PN7120],

--- a/libnfc-nci.pc.in
+++ b/libnfc-nci.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libnfc-nci
+Description: NXP NFC library
+Version: 1.0
+URL: https://github.com/NXPNFCLinux/linux_libnfc-nci
+Cflags: -I${includedir}
+Libs: -L${libdir} -lnfc_nci_linux


### PR DESCRIPTION
Allows easier re-use of the library in external build systems.

Looking at readelf output, I'm unsure whether a few more libs should be added to the .pc file:

```
$ readelf -d _install/lib/libnfc_nci_linux-1.so |grep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
```

(Maybe "-ldl -lm -lrt"?)

Anyway, this is a start.
