### PR TITLE
Bug Fix: Block number too large.

### DIFF
--- a/src/libnfc-nci/nfc/tags/rw_i93.c
+++ b/src/libnfc-nci/nfc/tags/rw_i93.c
@@ -59,7 +59,7 @@
 #define RW_I93_TOUT_STAY_QUIET                  200     /* stay quiet timeout   */
 #define RW_I93_READ_MULTI_BLOCK_SIZE            128     /* max reading data if read multi block is supported */
 #define RW_I93_FORMAT_DATA_LEN                  8       /* CC, zero length NDEF, Terminator TLV              */
-#define RW_I93_GET_MULTI_BLOCK_SEC_SIZE         512     /* max getting lock status if get multi block sec is supported */
+#define RW_I93_GET_MULTI_BLOCK_SEC_SIZE         253     /* max getting lock status if get multi block sec is supported */
 
 /* main state */
 enum


### PR DESCRIPTION
Though the pnx driver supports 512 bytes, most of the smartphones only support
rx frame of 256 bytes. Adding CRC (2bytes) + flag(1byte) the limit by default should be 253 bytes.
This number has no effect for tags <= 4k.
For high density tags, the native ndef detection stops with an error.

To do: Make this value dynamic and function of reader capabilities.

Test: Nexus 6P native tag detection on M24LR64 from STM