### PR TITLE
Bug Fix: Not compliant with NFC Type4 specifications

### DIFF
--- a/src/libnfc-nci/nfc/tags/rw_t4t.c
+++ b/src/libnfc-nci/nfc/tags/rw_t4t.c
@@ -1090,7 +1090,7 @@ static BOOLEAN rw_t4t_validate_cc_file (void)
     }
 
     if (  (p_t4t->cc_file.ndef_fc.write_access != T4T_FC_WRITE_ACCESS)
-        &&(p_t4t->cc_file.ndef_fc.write_access != T4T_FC_NO_WRITE_ACCESS)  )
+        &&(p_t4t->cc_file.ndef_fc.write_access & 0xF0)  )
     {
         RW_TRACE_ERROR1 ("rw_t4t_validate_cc_file (): Write Access (0x%02X) is invalid",
                           p_t4t->cc_file.ndef_fc.write_access);


### PR DESCRIPTION
Bug fix: NDEF not detected on Android phones

The NFC Forum Type 4 specifications mention that values 0x80 to 0xFE for the NDEF file
write access condition byte are proprietary. In the current library those values are considered
incorrect. Being considered incorrect when the Tag value is different from 0x00 or 0xFF, the stack
returns an error leading to a non detection of an NDEF message.
Here below the logcat on An Android phone :
12-17 03:37:01.157  3321  3628 E BrcmNfcNfa: rw_t4t_validate_cc_file (): Write Access (0x80) is invalid
12-17 03:37:01.157  3321  3628 E BrcmNfcNfa: rw_t4t_handle_error (): status:0xE7, sw1:0x00, sw2:0x00, state:0x2

According Type 4 specifications 0x80 is valid.