### PR TITLE
avoid unlocking mutexes twice - fixes segfault on platforms with hardware lock elision

### DIFF
--- a/src/halimpl/pn54x/utils/phNxpNciHal_utils.c
+++ b/src/halimpl/pn54x/utils/phNxpNciHal_utils.c
@@ -369,7 +369,6 @@ void phNxpNciHal_cleanup_monitor(void)
     if (nxpncihal_monitor != NULL)
     {
         pthread_mutex_destroy(&nxpncihal_monitor->concurrency_mutex);
-        REENTRANCE_UNLOCK();
         pthread_mutex_destroy(&nxpncihal_monitor->reentrance_mutex);
         phNxpNciHal_releaseall_cb_data();
         listDestroy(&nxpncihal_monitor->sem_list);

--- a/src/libnfc-nci/adaptation/NfcAdaptation.cpp
+++ b/src/libnfc-nci/adaptation/NfcAdaptation.cpp
@@ -200,7 +200,7 @@ void NfcAdaptation::Initialize ()
     GKI_enable ();
     GKI_create_task ((TASKPTR)NFCA_TASK, BTU_TASK, (INT8*)"NFCA_TASK", 0, 0, (pthread_cond_t*)NULL, NULL);
     {
-        AutoThreadMutex guard(mCondVar);
+        mCondVar.lock();
         GKI_create_task ((TASKPTR)Thread, MMI_TASK, (INT8*)"NFCA_THREAD", 0, 0, (pthread_cond_t*)NULL, NULL);
         mCondVar.wait();
     }
@@ -284,7 +284,7 @@ UINT32 NfcAdaptation::Thread (UINT32 arg)
 
     {
         ThreadCondVar    CondVar;
-        AutoThreadMutex  guard(CondVar);
+        CondVar.lock();
         GKI_create_task ((TASKPTR)nfc_task, NFC_TASK, (INT8*)"NFC_TASK", 0, 0, (pthread_cond_t*)CondVar, (pthread_mutex_t*)CondVar);
         CondVar.wait();
     }


### PR DESCRIPTION
Unlocking a pthread mutex which is not locked results in undefined behavior. Platforms with support for hardware lock elision seem particularly sensitive - the program crashes with a segfault.
This patch fixes two instances where I observed a crash.