### PR TITLE
Fix typo in LDFLAGS version-info parameter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -364,7 +364,7 @@ libnfc_nci_linux_la_FLAGS += -DPH_NCI_NXP_HAL_ENABLE_FW_DOWNLOAD=FALSE
 
 libnfc_nci_linux_la_LIBADD = $(AC_LIBOBJS)
 libnfc_nci_linux_la_LDFLAGS := $(AM_LDFLAGS)
-libnfc_nci_linux_la_LDFLAGS += -shared -pthread -ldl -lrt -fPIC -release 1 -versionnfo 0:0:0
+libnfc_nci_linux_la_LDFLAGS += -shared -pthread -ldl -lrt -fPIC -release 1 -version-info 0:0:0
 
 
 nfcDemoApp_LDFLAGS = -pthread -ldl -lrt -lnfc_nci_linux


### PR DESCRIPTION
There is is a typo in `Makefile.am`. This commit fixes the typo and ensures the shared objects are correctly named and symlinked by version, during install.

Before:
```
libnfc_nci_linux-1.so
libnfc_nci_linux.so -> libnfc_nci_linux-1.so (symlink)
```

After:
```
libnfc_nci_linux-1.so.0 -> libnfc_nci_linux-1.so.0.0.0 (symlink)
libnfc_nci_linux-1.so.0.0.0
libnfc_nci_linux.so -> libnfc_nci_linux-1.so.0.0.0 (symlink)
```

This was suggested in #41 - and it was merged in R2.2 (39d2fe6). However, it was removed in R2.4 (8476ea1) so the problem regressed.

Similar to #41, I also detected this while developing a Yocto recipe for this library.