### PR TITLE
Fix format string in framework_LockMutex

### DIFF
--- a/demoapp/tools.c
+++ b/demoapp/tools.c
@@ -142,7 +142,7 @@ void framework_LockMutex(void * mutexHandle)
 	int res = pthread_mutex_lock(mutex->lock);
 	if (res)
 	{
-		printf("lock() failed errno %i\n",strerror (errno));
+		printf("lock() failed %s\n",strerror (errno));
 	}
 }
 


### PR DESCRIPTION
Function strerror() returns a string, not int. This line was probably forgotten during the change from `errno` to `strerror(errno)`. Let's do it the same way as in `framework_UnlockMutex`.