### PR TITLE
Fix wrong returns

### DIFF
--- a/src/halimpl/pn54x/log/phNxpLog.c
+++ b/src/halimpl/pn54x/log/phNxpLog.c
@@ -50,7 +50,7 @@ nci_log_level_t gLog_level;
  *nfc.nxp_log_level_global.
  *                  If value can be overridden by module log level.
  *
- * Returns          The value of global log level
+ * Returns          void
  *
  ******************************************************************************/
 static void phNxpLog_SetGlobalLogLevel(void) {
@@ -61,8 +61,6 @@ static void phNxpLog_SetGlobalLogLevel(void) {
     {
         gLog_level.global_log_level = (level > (unsigned char) num) ? level : (unsigned char) num;;
     }
-
-  return level;
 }
 /*******************************************************************************
  *

--- a/src/halimpl/pn54x/tml/lpcusbsio/lpcusbsio/framework_Map.c
+++ b/src/halimpl/pn54x/tml/lpcusbsio/lpcusbsio/framework_Map.c
@@ -181,6 +181,8 @@ STATUS map_getAll(void* map, void ** elements, int * lenght)
 		}
 	    }
 	}
+
+	return lStatus;
 }
 
 STATUS map_remove(void* map, void* id)


### PR DESCRIPTION
Fix for a method declared void, but returning a value and for another one declared non-void, but missing a return statement.