### PR TITLE
Fixed issue where TLV detection for type 2 tags that caused NDEF Message TLV not to be found

### DIFF
--- a/src/libnfc-nci/nfc/tags/rw_t2t_ndef.c
+++ b/src/libnfc-nci/nfc/tags/rw_t2t_ndef.c
@@ -780,7 +780,7 @@ static void rw_t2t_handle_tlv_detect_rsp (UINT8 *p_data)
     if (!found && !failed)
     {
 
-        if (p_t2t->work_offset >= (p_t2t->tag_hdr[T2T_CC2_TMS_BYTE] * T2T_TMS_TAG_FACTOR))
+        if (p_t2t->work_offset >= (p_t2t->tag_hdr[T2T_CC2_TMS_BYTE] * T2T_TMS_TAG_FACTOR + T2T_FIRST_DATA_BLOCK * T2T_BLOCK_LEN))
         {
             if (  ((tlvtype == TAG_LOCK_CTRL_TLV) && (p_t2t->num_lockbytes > 0))
                 ||((tlvtype == TAG_MEM_CTRL_TLV) && (p_t2t->num_mem_tlvs > 0))  )
@@ -794,7 +794,7 @@ static void rw_t2t_handle_tlv_detect_rsp (UINT8 *p_data)
         }
         else
         {
-            if (rw_t2t_read ((UINT16) ((p_t2t->work_offset / T2T_BLOCK_LEN) + T2T_FIRST_DATA_BLOCK)) != NFC_STATUS_OK)
+            if (rw_t2t_read ((UINT16) (p_t2t->work_offset / T2T_BLOCK_LEN)) != NFC_STATUS_OK)
                 failed = TRUE;
         }
     }


### PR DESCRIPTION
Detection searched first block then third, skipping second.