### PR TITLE
Make use of ./configure --sysconfdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ pkgconfiglib_DATA = \
 	libnfc-nci.pc
 
 AM_CPPFLAGS = \
+	-DCONFIG_PATH='"$(configdir)/"' \
 	-I$(srcdir)/src/include \
 	$(INCLUDE_PARAMS) \
 	$(libnfc_nci_linux_la_FLAGS)

--- a/src/halimpl/pn54x/utils/phNxpConfig.cpp
+++ b/src/halimpl/pn54x/utils/phNxpConfig.cpp
@@ -49,7 +49,7 @@
 #if GENERIC_TARGET
 const char alternative_config_path[] = "/data/nfc/";
 #else
-const char alternative_config_path[] = "/usr/local/etc/";
+const char alternative_config_path[] = CONFIG_PATH;
 #endif
 
 const char transport_config_path[] = "/etc/";

--- a/src/libnfc-nci/adaptation/config.cpp
+++ b/src/libnfc-nci/adaptation/config.cpp
@@ -45,7 +45,7 @@
 
 #define LOG_TAG "NfcAdaptation"
 
-const char alternative_config_path[] = "/usr/local/etc/";
+const char alternative_config_path[] = CONFIG_PATH;
 const char transport_config_path[] = "/etc/";
 
 #define config_name             "libnfc-nci.conf"


### PR DESCRIPTION
Replaces the hard-coded path to the configuration directory "/usr/local/etc" with a preprocessor macro defined by `./configure --sysconfdir=foo/bar`.