### PR TITLE
linux_nfc_api.cpp: fix compiler error

### DIFF
--- a/src/service/linux_nfc_api.cpp
+++ b/src/service/linux_nfc_api.cpp
@@ -379,7 +379,7 @@ int doWriteT4tData(unsigned char *command, unsigned char *ndef_buffer, int ndef_
 int doReadT4tData(unsigned char *command, unsigned char *ndef_buffer, int *ndef_buffer_length)
 {
     int ret = 0;
-    if (ndef_buffer == NULL || ndef_buffer_length <= 0) {
+    if (ndef_buffer == NULL || *ndef_buffer_length <= 0) {
       NXPLOG_API_E ("%s: invalide buffer!", __FUNCTION__);
       return NFA_STATUS_FAILED;
     }


### PR DESCRIPTION
src/service/linux_nfc_api.cpp: In function ‘int doReadT4tData(unsigned char*, unsigned char*, int*)’: src/service/linux_nfc_api.cpp:382:51: error: ordered comparison of pointer with integer zero (‘int*’ and ‘int’)
  382 |     if (ndef_buffer == NULL || ndef_buffer_length <= 0) {

Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>