### PR TITLE
Stop leaking open file descriptors

### DIFF
--- a/src/android/utility/base/file.cpp
+++ b/src/android/utility/base/file.cpp
@@ -67,7 +67,9 @@ bool ReadFileToString(const std::string& path, std::string* content, bool follow
   if (fd == -1) {
     return false;
   }
-  return ReadFdToString(fd, content);
+  bool ret = ReadFdToString(fd, content);
+  close(fd);
+  return ret;
 }
 bool WriteStringToFd(const std::string& content, int fd) {
   const char* p = content.data();


### PR DESCRIPTION
Function ReadFileToString does not close opened file and leaks open fds. After about 1k opened files libnfc-nci crashes.
