### PR TITLE
Fix null pointer check for ndef_buffer_length in doReadT4tData function

### DIFF
--- a/src/service/linux_nfc_api.cpp
+++ b/src/service/linux_nfc_api.cpp
@@ -379,7 +379,7 @@ int doWriteT4tData(unsigned char *command, unsigned char *ndef_buffer, int ndef_
 int doReadT4tData(unsigned char *command, unsigned char *ndef_buffer, int *ndef_buffer_length)
 {
     int ret = 0;
-    if (ndef_buffer == NULL || ndef_buffer_length <= 0) {
+    if (ndef_buffer == NULL || ndef_buffer_length == NULL || *ndef_buffer_length <= 0) {
       NXPLOG_API_E ("%s: invalide buffer!", __FUNCTION__);
       return NFA_STATUS_FAILED;
     }


### PR DESCRIPTION
### Fix compiler error with gcc 13.x
`src/service/linux_nfc_api.cpp:382:51:` error: ordered comparison of pointer with integer zero ('int*' and 'int')
382 | if (ndef_buffer == NULL || ndef_buffer_length <= 0) {
